### PR TITLE
One fix and one addition.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.2.2
+- Fixed: The `pipeline` and `init` workflows need the `backend` parameter to be an object.
+
 ## 0.2.1
 - Fixed: The name of the workflow `pipeline` needed to be changed to match what is in the metadata.
 - Removed the `no_deploy` calls in plan.  This is now a `fail`.

--- a/actions/init.yaml
+++ b/actions/init.yaml
@@ -10,8 +10,8 @@ parameters:
     description: "Path of the terraform plan"
     required: true
   backend:
-    type: "string"
-    description: "Backend configuration file"
+    type: "object"
+    description: "Key-Value pairs of backend configuration options."
     required: false
   terraform_exec:
     type: "string"

--- a/actions/pipeline.yaml
+++ b/actions/pipeline.yaml
@@ -8,8 +8,8 @@ runner_type: "mistral-v2"
 
 parameters:
   backend:
-    type: "string"
-    description: "backend configuration variable file"
+    type: "object"
+    description: "Key-Value pairs of backend configuration options."
     required: false
   plan_path:
     type: "string"
@@ -27,4 +27,8 @@ parameters:
     type: "string"
     description: "The name of the Terraform workspace to use."
     default: "default"
+    required: false
+  destroy:
+    type: boolean
+    description: "Used if we want to run a destroy operation"
     required: false

--- a/actions/workflows/pipeline.yaml
+++ b/actions/workflows/pipeline.yaml
@@ -10,6 +10,7 @@ terraform.pipeline:
     - terraform_exec
     - workspace
     - variable_files
+    - destroy
 
   tasks:
     init:
@@ -60,12 +61,23 @@ terraform.pipeline:
         variable_files: <% $.variable_files %>
 
       on-success:
-        - apply
+        - apply: <% not $.destroy %>
+        - destroy: <% $.destroy %>
       on-error:
         - fail
 
     apply:
       action: terraform.apply
+
+      input:
+        plan_path: <% $.plan_path %>
+        terraform_exec: <% $.terraform_exec %>
+        variable_files: <% $.variable_files %>
+      on-error:
+        - fail
+
+    destroy:
+      action: terraform.destroy
 
       input:
         plan_path: <% $.plan_path %>

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ runner_type: "python-script"
 description: Terraform integrations
 keywords:
     - terraform
-version: 0.2.1
+version: 0.2.2
 author: Martez Reed
 email: martez.reed@greenreedtech.com


### PR DESCRIPTION
The backend parameter actually needs to be an object which is then parsed by terraform.  Additionally a new "delete" boolean is made available to the pipeline action.  This is so someone can do a pipeline-destroy as well as the default pipeline-apply.