### PR TITLE
update/python-terraform-module-outdated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 # Change Log
+## 0.2.5
+- Fixed: requirements.txt was installing an old version of the python-terraform module
+
 ## 0.2.4
 - Added: action to import objects into terraform files
 - Added: state_file_path and variable_dict variables to destroy action

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,6 +5,6 @@ runner_type: "python-script"
 description: Terraform integrations
 keywords:
     - terraform
-version: 0.2.4
+version: 0.2.5
 author: Martez Reed
 email: martez.reed@greenreedtech.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
--e git+https://github.com/beelit94/python-terraform.git@bd6528e68e9faade907170955fbe3f799ffd0ad7#egg=python-terraform
+-e git+https://github.com/beelit94/python-terraform.git@develop#egg=python-terraform
+


### PR DESCRIPTION
There was a bug in the python-terraform module that was giving an error on plan and apply after upgrading to Terraform 12. The fix for it is:

https://github.com/beelit94/python-terraform/pull/48/files

This pack is currently installing that module from a commit made in 2017 so it doesn't have the latest fixes