### PR TITLE
Add timeout parameter for long running terraform.apply and terraform.destroy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3.1
+
+- Added: timeout parameter to pipeline workflow allowing long running `apply` and `destroy` (above ST2 default of 600 seconds)
+
 ## 0.3.0
 
 - Changed: Orquesta-ified the pipeline workflow

--- a/actions/pipeline.yaml
+++ b/actions/pipeline.yaml
@@ -36,3 +36,8 @@ parameters:
     type: boolean
     description: "Used if we want to run a destroy operation"
     required: false
+  timeout:
+    type: "integer"
+    description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds"
+    required: false
+    default: 600

--- a/actions/workflows/pipeline.yaml
+++ b/actions/workflows/pipeline.yaml
@@ -73,7 +73,7 @@ tasks:
           - destroy
 
   apply:
-    action: terraform.apply 
+    action: terraform.apply
 
     input:
       plan_path: <% ctx().plan_path %>

--- a/actions/workflows/pipeline.yaml
+++ b/actions/workflows/pipeline.yaml
@@ -10,6 +10,7 @@ input:
   - variable_dict
   - variable_files
   - destroy
+  - timeout
 
 tasks:
   init:
@@ -72,13 +73,14 @@ tasks:
           - destroy
 
   apply:
-    action: terraform.apply
+    action: terraform.apply 
 
     input:
       plan_path: <% ctx().plan_path %>
       terraform_exec: <% ctx().terraform_exec %>
       variable_dict: <% ctx().variable_dict %>
       variable_files: <% ctx().variable_files %>
+      timeout: <% ctx(timeout) %>
 
   destroy:
     action: terraform.destroy

--- a/actions/workflows/pipeline.yaml
+++ b/actions/workflows/pipeline.yaml
@@ -90,3 +90,4 @@ tasks:
       terraform_exec: <% ctx().terraform_exec %>
       variable_dict: <% ctx().variable_dict %>
       variable_files: <% ctx().variable_files %>
+      timeout: <% ctx(timeout) %>

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ runner_type: "python-script"
 description: Terraform integrations
 keywords:
   - terraform
-version: 0.3.0
+version: 0.3.1
 author: Martez Reed
 email: martez.reed@greenreedtech.com
 python_versions:


### PR DESCRIPTION
This PR adds timeout parameter allowing to the pipeline above 600 seconds ( Stackstorm action timeout default)

## Before 

`terraform.apply` interrupted at 600s

![image](https://user-images.githubusercontent.com/17888379/77021800-0e068b00-6988-11ea-8349-7eefaeb537b4.png)


## After

`terraform.apply` finished successfully

![image](https://user-images.githubusercontent.com/17888379/77021931-7d7c7a80-6988-11ea-931e-d828cc014726.png)
