### PR TITLE
pin python-terraform to 0.10.1 instead of develop branch

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.3.2
+
+- Fixed: Pin `python-terraform` version to `0.10.1` in requirements.txt instead of using the develop branch. Visit
+ [this](https://github.com/StackStorm-Exchange/stackstorm-terraform/issues/18) for more details.
+
 ## 0.3.1
 
 - Added: timeout parameter to pipeline workflow allowing long running `apply` and `destroy` (above ST2 default of 600 seconds)

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,3 @@ keywords:
 version: 0.3.1
 author: Martez Reed
 email: martez.reed@greenreedtech.com
-python_versions:
-  - "2"
-  - "3"

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ runner_type: "python-script"
 description: Terraform integrations
 keywords:
   - terraform
-version: 0.3.1
+version: 0.3.2
 author: Martez Reed
 email: martez.reed@greenreedtech.com
 python_versions:

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,3 +8,6 @@ keywords:
 version: 0.3.1
 author: Martez Reed
 email: martez.reed@greenreedtech.com
+python_versions:
+  - "2"
+  - "3"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/beelit94/python-terraform.git@develop#egg=python-terraform
+python-terraform==0.10.1
 


### PR DESCRIPTION
fixes: #18 