### PR TITLE
update/pass-state-file-to-output

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,7 @@
 
 ## 0.4.1
 - Fixed: Passed tfstate file to output function in lib/action.py to retrieve outputs on any tfstate file instead of only terraform.tfstate
+- Added: Parameter for defining state file in output action
 
 ## 0.4.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.4.1
+- Fixed: Passed tfstate file to output function in lib/action.py to retrieve outputs on any tfstate file instead of only terraform.tfstate
+
 ## 0.4.0
 
 - Added: Support for streaming output in real-time.

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -28,10 +28,7 @@ class TerraformBaseAction(Action):
         if return_output:
             output = None
             if return_code in valid_return_codes:
-                if self.terraform.state is not None:
-                    output = self.terraform.output(state=self.terraform.state)
-                else:
-                    output = self.terraform.output()
+                output = self.terraform.output(state=self.terraform.state)
         else:
             output = TerraformBaseAction.concat_std_output(stdout, stderr)
 

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -28,7 +28,10 @@ class TerraformBaseAction(Action):
         if return_output:
             output = None
             if return_code in valid_return_codes:
-                output = self.terraform.output()
+                if self.terraform.state is not None:
+                    output = self.terraform.output(state=self.terraform.state)
+                else:
+                    output = self.terraform.output()
         else:
             output = TerraformBaseAction.concat_std_output(stdout, stderr)
 

--- a/actions/output.py
+++ b/actions/output.py
@@ -3,7 +3,7 @@ from lib import action
 
 
 class Output(action.TerraformBaseAction):
-    def run(self, plan_path, terraform_exec):
+    def run(self, plan_path, state_file_path, terraform_exec):
         """
         Output output variables from the state file.
 
@@ -16,4 +16,4 @@ class Output(action.TerraformBaseAction):
         """
         os.chdir(plan_path)
         self.terraform.terraform_bin_path = terraform_exec
-        return self.terraform.output()
+        return self.terraform.output(state=state_file_path)

--- a/actions/output.yaml
+++ b/actions/output.yaml
@@ -9,6 +9,10 @@ parameters:
     type: "string"
     description: "Path of the terraform plan"
     required: true
+  state_file_path:
+    type: "string"
+    description: "Path of terraform state file"
+    required: false
   terraform_exec:
     type: "string"
     description: "Terraform executable path (default: terraform in the $PATH)"

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ runner_type: "python-script"
 description: Terraform integrations
 keywords:
   - terraform
-version: 0.4.0
+version: 0.4.1
 author: Martez Reed
 email: martez.reed@greenreedtech.com
 python_versions:

--- a/tests/test_action_lib_action.py
+++ b/tests/test_action_lib_action.py
@@ -105,7 +105,7 @@ class ActionTestCase(TerraformBaseActionTestCase):
 
         # Verify the results
         self.assertEqual(result, expected_result)
-        mock_output.assert_called_once()
+        mock_output.assert_called_with(state=None)
 
     def test_check_result_fail_with_output(self):
         action = self.get_action_instance({})

--- a/tests/test_action_lib_action.py
+++ b/tests/test_action_lib_action.py
@@ -48,7 +48,38 @@ class ActionTestCase(TerraformBaseActionTestCase):
         self.assertEqual(result, expected_result)
 
     @mock.patch("lib.action.Terraform.output")
-    def test_check_result_success_with_output(self, mock_output):
+    def test_check_result_success_with_output_with_state(self, mock_output):
+        action = self.get_action_instance({})
+
+        # Set terraform variables for test
+        action.terraform.terraform_bin_path = "/usr/bin/terraform"
+        action.terraform.working_dir = "/terraform"
+        test_state_file = "/path/to/state/file"
+        action.terraform.state = test_state_file
+
+        # Declare test input values
+        test_return_code = 0
+        test_stdout = "Terraform has been successfully initialized!"
+        test_stderr = ""
+
+        # Declare test Terraform.output return values
+        mock_output.return_value = dict()
+        expected_result = (True, dict())
+
+        # Execute the run function
+        result = action.check_result(
+            test_return_code,
+            test_stdout,
+            test_stderr,
+            return_output=True
+        )
+
+        # Verify the results
+        self.assertEqual(result, expected_result)
+        mock_output.assert_called_with(state=test_state_file)
+
+    @mock.patch("lib.action.Terraform.output")
+    def test_check_result_success_with_output_no_state(self, mock_output):
         action = self.get_action_instance({})
 
         # Set terraform variables for test
@@ -74,6 +105,7 @@ class ActionTestCase(TerraformBaseActionTestCase):
 
         # Verify the results
         self.assertEqual(result, expected_result)
+        mock_output.assert_called_once()
 
     def test_check_result_fail_with_output(self):
         action = self.get_action_instance({})

--- a/tests/test_action_output.py
+++ b/tests/test_action_output.py
@@ -13,7 +13,32 @@ class OutputTestCase(TerraformBaseActionTestCase):
 
     @mock.patch("output.os.chdir")
     @mock.patch("lib.action.Terraform.output")
-    def test_run(self, mock_output, mock_chdir):
+    def test_run_state_file(self, mock_output, mock_chdir):
+        action = self.get_action_instance({})
+        # Declare test input values
+        test_plan_path = "/terraform"
+        test_state_file_path = "/path/to/state/file"
+        test_terraform_exec = "/usr/bin/terraform"
+
+        # Declare test Terraform.output return values
+        expected_result = "result"
+        mock_output.return_value = expected_result
+
+        mock_chdir.return_value = "success"
+
+        # Execute the run function
+        result = action.run(test_plan_path, test_state_file_path, test_terraform_exec)
+
+        # Verify the results
+        self.assertEqual(result, expected_result)
+        self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
+        self.assertTrue(mock_output.called)
+        mock_chdir.assert_called_with(test_plan_path)
+        mock_output.assert_called_with(state=test_state_file_path)
+
+    @mock.patch("output.os.chdir")
+    @mock.patch("lib.action.Terraform.output")
+    def test_run_no_state_file(self, mock_output, mock_chdir):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -26,10 +51,11 @@ class OutputTestCase(TerraformBaseActionTestCase):
         mock_chdir.return_value = "success"
 
         # Execute the run function
-        result = action.run(test_plan_path, test_terraform_exec)
+        result = action.run(test_plan_path, None, test_terraform_exec)
 
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertTrue(mock_output.called)
         mock_chdir.assert_called_with(test_plan_path)
+        mock_output.assert_called_with(state=None)


### PR DESCRIPTION
This currently only returns outputs that are defined in the default terraform.tfstate file. Since we name our tfstate files differently we need to pass that filename to retrieve the desired outputs.