### PR TITLE
Bump version to 0.5.2

### DIFF
--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ runner_type: "python-script"
 description: Terraform integrations
 keywords:
   - terraform
-version: 0.5.1
+version: 0.5.2
 author: Martez Reed
 email: martez.reed@greenreedtech.com
 python_versions:


### PR DESCRIPTION
I forgot to do this in the last PR, and the version on stackstorm exchange doesn't actually pull in my changes.