### PR TITLE
Support latest terraform versions with newer library.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 2.0.0
+* Moving to newer dda_python_terraform library! (This will allow support for terraform > 0.14)
+* Utilize version and set semantic_version within the library after being initialized for each action
+
 ## 1.1.1
 * Bugfix: Invalid variable name in output.
 

--- a/actions/apply.py
+++ b/actions/apply.py
@@ -1,7 +1,7 @@
 import os
 from lib import action
-from python_terraform import IsFlagged
-
+from dda_python_terraform import IsFlagged
+from dda_python_terraform.terraform import TerraformCommandError
 
 class Apply(action.TerraformBaseAction):
     def run(self, plan_path, state_file_path, target_resources, terraform_exec,
@@ -22,6 +22,7 @@ class Apply(action.TerraformBaseAction):
         - dict: Terraform output command output
         """
         os.chdir(plan_path)
+        self.set_semantic_version()
         self.terraform.state = state_file_path
         self.terraform.targets = target_resources
         self.terraform.terraform_bin_path = terraform_exec
@@ -32,7 +33,7 @@ class Apply(action.TerraformBaseAction):
             plan_path,
             skip_plan=True,
             auto_approve=IsFlagged,
-            capture_output=False
+            capture_output=False,
+            raise_on_error=False
         )
-
         return self.check_result(return_code, stdout, stderr, return_output=True)

--- a/actions/create_workspace.py
+++ b/actions/create_workspace.py
@@ -1,5 +1,6 @@
 import os
 from lib import action
+from dda_python_terraform.terraform import TerraformCommandError
 
 
 class CreateWorkspace(action.TerraformBaseAction):
@@ -17,6 +18,8 @@ class CreateWorkspace(action.TerraformBaseAction):
         """
         os.chdir(plan_path)
         self.terraform.terraform_bin_path = terraform_exec
+        self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace("new", workspace,
-                                                               '-no-color')
+                                                                '-no-color', 
+                                                                raise_on_error=False)
         return self.check_result(return_code, stdout, stderr)

--- a/actions/delete_workspace.py
+++ b/actions/delete_workspace.py
@@ -1,5 +1,6 @@
 import os
 from lib import action
+from dda_python_terraform.terraform import TerraformCommandError
 
 
 class DeleteWorkspace(action.TerraformBaseAction):
@@ -17,6 +18,8 @@ class DeleteWorkspace(action.TerraformBaseAction):
         """
         os.chdir(plan_path)
         self.terraform.terraform_bin_path = terraform_exec
+        self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace("delete", '-force', workspace,
-                                                               '-no-color')
+                                                            '-no-color', raise_on_error=False)
+
         return self.check_result(return_code, stdout, stderr)

--- a/actions/destroy.py
+++ b/actions/destroy.py
@@ -1,7 +1,7 @@
 import os
 from lib import action
-from python_terraform import IsFlagged
-
+from dda_python_terraform import IsFlagged
+from dda_python_terraform.terraform import TerraformCommandError
 
 class Destroy(action.TerraformBaseAction):
     def run(self, plan_path, state_file_path, target_resources, terraform_exec,
@@ -23,6 +23,7 @@ class Destroy(action.TerraformBaseAction):
         """
         os.chdir(plan_path)
         self.terraform.terraform_bin_path = terraform_exec
+        self.set_semantic_version()
         self.terraform.targets = target_resources
         return_code, stdout, stderr = self.terraform.destroy(
             plan_path,
@@ -30,6 +31,8 @@ class Destroy(action.TerraformBaseAction):
             var=variable_dict,
             state=state_file_path,
             force=IsFlagged,
-            capture_output=False
+            capture_output=False,
+            raise_on_error=False
         )
+
         return self.check_result(return_code, stdout, stderr, return_output=True)

--- a/actions/import_object.py
+++ b/actions/import_object.py
@@ -1,5 +1,6 @@
 import os
 from lib import action
+from dda_python_terraform.terraform import TerraformCommandError
 
 
 class Import(action.TerraformBaseAction):
@@ -23,8 +24,10 @@ class Import(action.TerraformBaseAction):
         """
         os.chdir(plan_path)
         self.terraform.terraform_bin_path = terraform_exec
+        self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.import_cmd(resource_name, hypervisor_object,
                                                                 state=state_file_path,
                                                                 var_file=variable_files,
-                                                                var=variable_dict)
+                                                                var=variable_dict,
+                                                                raise_on_error=False)
         return self.check_result(return_code, stdout, stderr)

--- a/actions/init.py
+++ b/actions/init.py
@@ -1,6 +1,7 @@
 import os
 from lib import action
-from python_terraform import IsFlagged, IsNotFlagged
+from dda_python_terraform import IsFlagged, IsNotFlagged
+from dda_python_terraform.terraform import TerraformCommandError
 
 
 class Init(action.TerraformBaseAction):
@@ -19,12 +20,14 @@ class Init(action.TerraformBaseAction):
         """
         os.chdir(plan_path)
         self.terraform.terraform_bin_path = terraform_exec
+        self.set_semantic_version()
 
         return_code, stdout, stderr = self.terraform.init(
             plan_path,
             backend_config=backend,
             capture_output=False,
-            upgrade=IsFlagged if upgrade else IsNotFlagged
+            upgrade=IsFlagged if upgrade else IsNotFlagged,
+            raise_on_error=False
         )
 
         return self.check_result(return_code, stdout, stderr)

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -1,11 +1,11 @@
 from st2common.runners.base_action import Action
-from python_terraform import Terraform
-
+from dda_python_terraform import Terraform
+import json
 
 class TerraformBaseAction(Action):
     def __init__(self, config):
         """Creates a new BaseAction given a StackStorm config object (kwargs works too)
-        Also stores the Terraform class from python_terraform in a class variable
+        Also stores the Terraform class from dda_python_terraform in a class variable
         :param config: StackStorm configuration object for the pack
         :returns: a new BaseAction
         """
@@ -35,6 +35,16 @@ class TerraformBaseAction(Action):
         # Capture success status vs valid return codes and return result
         success = (return_code in valid_return_codes)
         return success, output
+
+    def set_semantic_version(self):
+        """Set the semantic version string on the dda terraform library.
+        This is called with each action in case the different exec is
+        set.
+        """
+        # Get the verison of terraform
+        _, stdout, _ = self.terraform.version(json=True)
+        version = json.loads(stdout)['terraform_version']
+        self.terraform.terraform_semantic_version = version
 
     @staticmethod
     def concat_std_output(stdout, stderr):

--- a/actions/list_workspaces.py
+++ b/actions/list_workspaces.py
@@ -1,5 +1,6 @@
 import os
 from lib import action
+from dda_python_terraform.terraform import TerraformCommandError
 
 
 class ListWorkspaces(action.TerraformBaseAction):
@@ -16,6 +17,7 @@ class ListWorkspaces(action.TerraformBaseAction):
         """
         os.chdir(plan_path)
         self.terraform.terraform_bin_path = terraform_exec
-        return_code, stdout, stderr = self.terraform.workspace("list")
+        self.set_semantic_version()
+        return_code, stdout, stderr = self.terraform.workspace("list", raise_on_error=False)
 
         return self.check_result(return_code, stdout, stderr)

--- a/actions/output.py
+++ b/actions/output.py
@@ -16,4 +16,5 @@ class Output(action.TerraformBaseAction):
         """
         os.chdir(plan_path)
         self.terraform.terraform_bin_path = terraform_exec
+        self.set_semantic_version()
         return self.terraform.output(state=state_file_path)

--- a/actions/plan.py
+++ b/actions/plan.py
@@ -1,5 +1,6 @@
 import os
 from lib import action
+from dda_python_terraform.terraform import TerraformCommandError
 
 
 class Plan(action.TerraformBaseAction):
@@ -26,8 +27,10 @@ class Plan(action.TerraformBaseAction):
         self.terraform.terraform_bin_path = terraform_exec
         self.terraform.var_file = variable_files
         self.terraform.variables = variable_dict
-
-        return_code, stdout, stderr = self.terraform.plan(plan_path, capture_output=False)
+        self.set_semantic_version()
+        return_code, stdout, stderr = self.terraform.plan(plan_path,
+        capture_output=False,
+        raise_on_error=False)
 
         return self.check_result(
             return_code,

--- a/actions/select_workspace.py
+++ b/actions/select_workspace.py
@@ -1,5 +1,6 @@
 import os
 from lib import action
+from dda_python_terraform.terraform import TerraformCommandError
 
 
 class SelectWorkspace(action.TerraformBaseAction):
@@ -17,6 +18,7 @@ class SelectWorkspace(action.TerraformBaseAction):
         """
         os.chdir(plan_path)
         self.terraform.terraform_bin_path = terraform_exec
+        self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace("select", workspace,
-                                                               '-no-color')
+                                            '-no-color', raise_on_error=False)
         return self.check_result(return_code, stdout, stderr)

--- a/actions/show.py
+++ b/actions/show.py
@@ -1,5 +1,6 @@
 import os
 from lib import action
+from dda_python_terraform.terraform import TerraformCommandError
 
 
 class Show(action.TerraformBaseAction):
@@ -16,6 +17,7 @@ class Show(action.TerraformBaseAction):
         """
         os.chdir(plan_path)
         self.terraform.terraform_bin_path = terraform_exec
-        return_code, stdout, stderr = self.terraform.show('-no-color')
+        self.set_semantic_version()
+        return_code, stdout, stderr = self.terraform.show('-no-color', raise_on_error=False)
 
         return self.check_result(return_code, stdout, stderr)

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ runner_type: "python-script"
 description: Terraform integrations
 keywords:
   - terraform
-version: 1.1.1
+version: 2.0.0
 author: Martez Reed
 email: martez.reed@greenreedtech.com
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-python-terraform==0.10.1
+dda-python-terraform==2.0.1
 

--- a/tests/test_action_apply.py
+++ b/tests/test_action_apply.py
@@ -1,5 +1,5 @@
 from terraform_base_action_test_case import TerraformBaseActionTestCase
-from python_terraform import IsFlagged
+from dda_python_terraform import IsFlagged
 from apply import Apply
 import mock
 

--- a/tests/test_action_destroy.py
+++ b/tests/test_action_destroy.py
@@ -1,6 +1,6 @@
 from terraform_base_action_test_case import TerraformBaseActionTestCase
 from destroy import Destroy
-from python_terraform import IsFlagged
+from dda_python_terraform import IsFlagged
 import mock
 
 

--- a/tests/test_action_init.py
+++ b/tests/test_action_init.py
@@ -1,6 +1,6 @@
 from terraform_base_action_test_case import TerraformBaseActionTestCase
 from init import Init
-from python_terraform import IsFlagged, IsNotFlagged
+from dda_python_terraform import IsFlagged, IsNotFlagged
 import mock
 
 


### PR DESCRIPTION
The current python-terraform library was no longer being developed. The dda-python-library now supports the latest terraform versions and is being actively maintained.