### PR TITLE
Fix apply for non default terraform binary path

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 2.0.1
+* Fixed: apply for non default terraform binary path
+
 ## 2.0.0
 * Moving to newer dda_python_terraform library! (This will allow support for terraform > 0.14)
 * Utilize version and set semantic_version within the library after being initialized for each action

--- a/actions/apply.py
+++ b/actions/apply.py
@@ -22,12 +22,12 @@ class Apply(action.TerraformBaseAction):
         - dict: Terraform output command output
         """
         os.chdir(plan_path)
-        self.set_semantic_version()
         self.terraform.state = state_file_path
         self.terraform.targets = target_resources
         self.terraform.terraform_bin_path = terraform_exec
         self.terraform.var_file = variable_files
         self.terraform.variables = variable_dict
+        self.set_semantic_version()
 
         return_code, stdout, stderr = self.terraform.apply(
             plan_path,

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ runner_type: "python-script"
 description: Terraform integrations
 keywords:
   - terraform
-version: 2.0.0
+version: 2.0.1
 author: Martez Reed
 email: martez.reed@greenreedtech.com
 python_versions:


### PR DESCRIPTION
Terraform version needs to be verified when the path for terraform binary file is set.