### PR TITLE
Setting path with working_dir / Fixes unit tests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 2.0.2
+* Fixed: removed 'os.chdir' calls that were causing os errors
+* https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/0-15#commands-accepting-a-configuration-directory-argument
+* Fixed: unit tests
+
 ## 2.0.1
 * Fixed: apply for non default terraform binary path
 

--- a/actions/apply.py
+++ b/actions/apply.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 from dda_python_terraform import IsFlagged
 
@@ -21,7 +20,7 @@ class Apply(action.TerraformBaseAction):
         Returns:
         - dict: Terraform output command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.state = state_file_path
         self.terraform.targets = target_resources
         self.terraform.terraform_bin_path = terraform_exec
@@ -30,7 +29,6 @@ class Apply(action.TerraformBaseAction):
         self.set_semantic_version()
 
         return_code, stdout, stderr = self.terraform.apply(
-            plan_path,
             skip_plan=True,
             auto_approve=IsFlagged,
             capture_output=False,

--- a/actions/create_workspace.py
+++ b/actions/create_workspace.py
@@ -18,6 +18,6 @@ class CreateWorkspace(action.TerraformBaseAction):
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace("new", workspace,
-                                                                '-no-color', 
-                                                                raise_on_error=False)
+                                                               '-no-color',
+                                                               raise_on_error=False)
         return self.check_result(return_code, stdout, stderr)

--- a/actions/create_workspace.py
+++ b/actions/create_workspace.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -15,7 +14,7 @@ class CreateWorkspace(action.TerraformBaseAction):
         Returns:
         - dict: Terraform workspace new command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace("new", workspace,

--- a/actions/delete_workspace.py
+++ b/actions/delete_workspace.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -15,7 +14,7 @@ class DeleteWorkspace(action.TerraformBaseAction):
         Returns:
         - dict: Terraform workspace delete command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace(

--- a/actions/destroy.py
+++ b/actions/destroy.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 from dda_python_terraform import IsFlagged
 
@@ -21,12 +20,11 @@ class Destroy(action.TerraformBaseAction):
         Returns:
         - dict: Terraform destroy command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         self.terraform.targets = target_resources
         return_code, stdout, stderr = self.terraform.destroy(
-            plan_path,
             var_file=variable_files,
             var=variable_dict,
             state=state_file_path,

--- a/actions/import_object.py
+++ b/actions/import_object.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -21,7 +20,7 @@ class Import(action.TerraformBaseAction):
         Returns:
         - dict: Terraform destroy command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.import_cmd(

--- a/actions/init.py
+++ b/actions/init.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 from dda_python_terraform import IsFlagged, IsNotFlagged
 
@@ -17,12 +16,11 @@ class Init(action.TerraformBaseAction):
         Returns:
         - dict: Terraform init command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
 
         return_code, stdout, stderr = self.terraform.init(
-            plan_path,
             backend_config=backend,
             capture_output=False,
             upgrade=IsFlagged if upgrade else IsNotFlagged,

--- a/actions/list_workspaces.py
+++ b/actions/list_workspaces.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -14,7 +13,7 @@ class ListWorkspaces(action.TerraformBaseAction):
         Returns:
         - dict: Terraform workspace list command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace(

--- a/actions/output.py
+++ b/actions/output.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -14,7 +13,7 @@ class Output(action.TerraformBaseAction):
         Returns:
         - dict: Terraform output command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return self.terraform.output(state=state_file_path)

--- a/actions/plan.py
+++ b/actions/plan.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -20,7 +19,7 @@ class Plan(action.TerraformBaseAction):
         Returns:
         - dict: Terraform output command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.state = state_file_path
         self.terraform.targets = target_resources
         self.terraform.terraform_bin_path = terraform_exec
@@ -28,7 +27,6 @@ class Plan(action.TerraformBaseAction):
         self.terraform.variables = variable_dict
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.plan(
-            plan_path,
             capture_output=False,
             raise_on_error=False)
 

--- a/actions/select_workspace.py
+++ b/actions/select_workspace.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -15,7 +14,7 @@ class SelectWorkspace(action.TerraformBaseAction):
         Returns:
         - dict: Terraform workspace select command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.workspace(

--- a/actions/show.py
+++ b/actions/show.py
@@ -1,4 +1,3 @@
-import os
 from lib import action
 
 
@@ -14,7 +13,7 @@ class Show(action.TerraformBaseAction):
         Returns:
         - dict: Terraform show command output
         """
-        os.chdir(plan_path)
+        self.terraform.working_dir = plan_path
         self.terraform.terraform_bin_path = terraform_exec
         self.set_semantic_version()
         return_code, stdout, stderr = self.terraform.show(

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ runner_type: "python-script"
 description: Terraform integrations
 keywords:
   - terraform
-version: 2.0.1
+version: 2.0.2
 author: Martez Reed
 email: martez.reed@greenreedtech.com
 python_versions:

--- a/tests/test_action_apply.py
+++ b/tests/test_action_apply.py
@@ -14,7 +14,7 @@ class PlanTestCase(TerraformBaseActionTestCase):
 
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.apply")
-    def test_run(self, mock_apply, mock_check_result, mock_chdir):
+    def test_run(self, mock_apply, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -31,8 +31,6 @@ class PlanTestCase(TerraformBaseActionTestCase):
 
         mock_apply.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -47,7 +45,6 @@ class PlanTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertEqual(action.terraform.var_file, test_variable_files)
         self.assertEqual(action.terraform.variables, test_variable_dict)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_apply.assert_called_with(
             skip_plan=True,
             auto_approve=IsFlagged,

--- a/tests/test_action_apply.py
+++ b/tests/test_action_apply.py
@@ -12,7 +12,6 @@ class PlanTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Apply)
 
-    @mock.patch("list_workspaces.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.apply")
     def test_run(self, mock_apply, mock_check_result, mock_chdir):
@@ -50,7 +49,6 @@ class PlanTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.variables, test_variable_dict)
         mock_chdir.assert_called_with(test_plan_path)
         mock_apply.assert_called_with(
-            test_plan_path,
             skip_plan=True,
             auto_approve=IsFlagged,
             capture_output=False

--- a/tests/test_action_apply.py
+++ b/tests/test_action_apply.py
@@ -50,7 +50,8 @@ class PlanTestCase(TerraformBaseActionTestCase):
         mock_apply.assert_called_with(
             skip_plan=True,
             auto_approve=IsFlagged,
-            capture_output=False
+            capture_output=False,
+            raise_on_error=False
         )
         mock_check_result.assert_called_with(
             test_return_code,

--- a/tests/test_action_apply.py
+++ b/tests/test_action_apply.py
@@ -12,9 +12,10 @@ class PlanTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Apply)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.apply")
-    def test_run(self, mock_apply, mock_check_result):
+    def test_run(self, mock_apply, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -29,6 +30,7 @@ class PlanTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_apply.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"

--- a/tests/test_action_create_workspace.py
+++ b/tests/test_action_create_workspace.py
@@ -13,7 +13,7 @@ class CreateWorkspaceTestCase(TerraformBaseActionTestCase):
 
     @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
-    @mock.patch("lib.action.Terraform.__getattr__")
+    @mock.patch("lib.action.Terraform.__getattr__", create=True)
     def test_run(self, mock_workspace, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values

--- a/tests/test_action_create_workspace.py
+++ b/tests/test_action_create_workspace.py
@@ -11,9 +11,10 @@ class CreateWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, CreateWorkspace)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result):
+    def test_run(self, mock_workspace, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -25,6 +26,7 @@ class CreateWorkspaceTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"

--- a/tests/test_action_create_workspace.py
+++ b/tests/test_action_create_workspace.py
@@ -11,10 +11,9 @@ class CreateWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, CreateWorkspace)
 
-    @mock.patch("create_workspace.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result, mock_chdir):
+    def test_run(self, mock_workspace, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -28,8 +27,6 @@ class CreateWorkspaceTestCase(TerraformBaseActionTestCase):
 
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -39,7 +36,6 @@ class CreateWorkspaceTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_workspace.assert_called_with("workspace")
         action.terraform.workspace.assert_called_with("new", test_workspace, "-no-color")
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_create_workspace.py
+++ b/tests/test_action_create_workspace.py
@@ -39,5 +39,8 @@ class CreateWorkspaceTestCase(TerraformBaseActionTestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         mock_workspace.assert_called_with("workspace")
-        action.terraform.workspace.assert_called_with("new", test_workspace, "-no-color")
+        action.terraform.workspace.assert_called_with("new",
+                                                      test_workspace,
+                                                      "-no-color",
+                                                      raise_on_error=False)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_delete_workspace.py
+++ b/tests/test_action_delete_workspace.py
@@ -11,10 +11,9 @@ class DeleteWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, DeleteWorkspace)
 
-    @mock.patch("delete_workspace.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result, mock_chdir):
+    def test_run(self, mock_workspace, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -28,8 +27,6 @@ class DeleteWorkspaceTestCase(TerraformBaseActionTestCase):
 
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -39,7 +36,6 @@ class DeleteWorkspaceTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_workspace.assert_called_with("workspace")
         action.terraform.workspace.assert_called_with("delete", "-force", test_workspace,
                                                       "-no-color")

--- a/tests/test_action_delete_workspace.py
+++ b/tests/test_action_delete_workspace.py
@@ -40,5 +40,5 @@ class DeleteWorkspaceTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         mock_workspace.assert_called_with("workspace")
         action.terraform.workspace.assert_called_with("delete", "-force", test_workspace,
-                                                      "-no-color")
+                                                      "-no-color", raise_on_error=False)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_delete_workspace.py
+++ b/tests/test_action_delete_workspace.py
@@ -11,9 +11,10 @@ class DeleteWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, DeleteWorkspace)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result):
+    def test_run(self, mock_workspace, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -25,6 +26,7 @@ class DeleteWorkspaceTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"

--- a/tests/test_action_destroy.py
+++ b/tests/test_action_destroy.py
@@ -12,10 +12,9 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Destroy)
 
-    @mock.patch("destroy.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.destroy")
-    def test_run(self, mock_destroy, mock_check_result, mock_chdir):
+    def test_run(self, mock_destroy, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -35,8 +34,6 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
-        mock_chdir.return_value = "success"
-
         # Execute the run function
         result = action.run(test_plan_path, test_state_file, test_target_resources,
                             test_terraform_exec, test_variable_dict, test_variable_files)
@@ -45,7 +42,6 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.targets, test_target_resources)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_destroy.assert_called_with(
             test_plan_path,
             var_file=test_variable_files,

--- a/tests/test_action_destroy.py
+++ b/tests/test_action_destroy.py
@@ -45,12 +45,12 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.targets, test_target_resources)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         mock_destroy.assert_called_with(
-            test_plan_path,
             var_file=test_variable_files,
             var=test_variable_dict,
             state=test_state_file,
             force=IsFlagged,
-            capture_output=False
+            capture_output=False,
+            raise_on_error=False
         )
         mock_check_result.assert_called_with(
             test_return_code,

--- a/tests/test_action_destroy.py
+++ b/tests/test_action_destroy.py
@@ -12,9 +12,10 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Destroy)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.destroy")
-    def test_run(self, mock_destroy, mock_check_result):
+    def test_run(self, mock_destroy, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -29,6 +30,7 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         test_stdout = "Object successfully destroyed!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_destroy.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"

--- a/tests/test_action_import_object.py
+++ b/tests/test_action_import_object.py
@@ -11,9 +11,10 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Import)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_import_cmd, mock_check_result):
+    def test_run(self, mock_import_cmd, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_hypervisor_object = '/dc.name/vm/folder/vm.name'
@@ -28,6 +29,8 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         test_return_code = 0
         test_stdout = "Object successfully destroyed!"
         test_stderr = ""
+
+        mock_version.return_value = '1.1.1'
 
         # mock_import_cmd.return_value = test_return_code, test_stdout, test_stderr
         action.terraform.import_cmd.return_value = test_return_code, test_stdout, test_stderr

--- a/tests/test_action_import_object.py
+++ b/tests/test_action_import_object.py
@@ -11,10 +11,9 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Import)
 
-    @mock.patch("destroy.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_import_cmd, mock_check_result, mock_chdir):
+    def test_run(self, mock_import_cmd, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_hypervisor_object = '/dc.name/vm/folder/vm.name'
@@ -36,8 +35,6 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
-        mock_chdir.return_value = "success"
-
         # Execute the run function
         result = action.run(test_hypervisor_object, test_plan_path, test_resource_name,
                             test_state_file, test_terraform_exec, test_variable_dict,
@@ -46,7 +43,6 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_import_cmd.assert_called_with('import_cmd')
         action.terraform.import_cmd.assert_called_with(test_resource_name, test_hypervisor_object,
                                                        state=test_state_file,

--- a/tests/test_action_import_object.py
+++ b/tests/test_action_import_object.py
@@ -50,5 +50,6 @@ class DestroyTestCase(TerraformBaseActionTestCase):
         action.terraform.import_cmd.assert_called_with(test_resource_name, test_hypervisor_object,
                                                        state=test_state_file,
                                                        var_file=test_variable_files,
-                                                       var=test_variable_dict)
+                                                       var=test_variable_dict,
+                                                       raise_on_error=False)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_init.py
+++ b/tests/test_action_init.py
@@ -43,7 +43,8 @@ class InitTestCase(TerraformBaseActionTestCase):
         mock_init.assert_called_with(
             backend_config=test_backend,
             capture_output=False,
-            upgrade=IsNotFlagged
+            upgrade=IsNotFlagged,
+            raise_on_error=False
         )
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
 
@@ -78,7 +79,8 @@ class InitTestCase(TerraformBaseActionTestCase):
         mock_init.assert_called_with(
             backend_config=test_backend,
             capture_output=False,
-            upgrade=IsFlagged
+            upgrade=IsFlagged,
+            raise_on_error=False
         )
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
 
@@ -113,6 +115,7 @@ class InitTestCase(TerraformBaseActionTestCase):
         mock_init.assert_called_with(
             backend_config=test_backend,
             capture_output=False,
-            upgrade=IsNotFlagged
+            upgrade=IsNotFlagged,
+            raise_on_error=False
         )
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_init.py
+++ b/tests/test_action_init.py
@@ -12,9 +12,10 @@ class InitTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Init)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
-    def test_run_upgrade_false(self, mock_init, mock_check_result):
+    def test_run_upgrade_false(self, mock_init, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -27,6 +28,7 @@ class InitTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_init.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"
@@ -45,9 +47,10 @@ class InitTestCase(TerraformBaseActionTestCase):
         )
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
-    def test_run_upgrade_true(self, mock_init, mock_check_result):
+    def test_run_upgrade_true(self, mock_init, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -60,6 +63,7 @@ class InitTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_init.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"
@@ -78,9 +82,10 @@ class InitTestCase(TerraformBaseActionTestCase):
         )
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
-    def test_run_upgrade_none(self, mock_init, mock_check_result):
+    def test_run_upgrade_none(self, mock_init, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -93,6 +98,7 @@ class InitTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_init.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"

--- a/tests/test_action_init.py
+++ b/tests/test_action_init.py
@@ -12,7 +12,6 @@ class InitTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Init)
 
-    @mock.patch("list_workspaces.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
     def test_run_upgrade_false(self, mock_init, mock_check_result, mock_chdir):
@@ -43,14 +42,12 @@ class InitTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         mock_chdir.assert_called_with(test_plan_path)
         mock_init.assert_called_with(
-            test_plan_path,
             backend_config=test_backend,
             capture_output=False,
             upgrade=IsNotFlagged
         )
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
 
-    @mock.patch("list_workspaces.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
     def test_run_upgrade_true(self, mock_init, mock_check_result, mock_chdir):
@@ -81,14 +78,12 @@ class InitTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         mock_chdir.assert_called_with(test_plan_path)
         mock_init.assert_called_with(
-            test_plan_path,
             backend_config=test_backend,
             capture_output=False,
             upgrade=IsFlagged
         )
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
 
-    @mock.patch("list_workspaces.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
     def test_run_upgrade_none(self, mock_init, mock_check_result, mock_chdir):
@@ -119,7 +114,6 @@ class InitTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         mock_chdir.assert_called_with(test_plan_path)
         mock_init.assert_called_with(
-            test_plan_path,
             backend_config=test_backend,
             capture_output=False,
             upgrade=IsNotFlagged

--- a/tests/test_action_init.py
+++ b/tests/test_action_init.py
@@ -14,7 +14,7 @@ class InitTestCase(TerraformBaseActionTestCase):
 
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
-    def test_run_upgrade_false(self, mock_init, mock_check_result, mock_chdir):
+    def test_run_upgrade_false(self, mock_init, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -29,8 +29,6 @@ class InitTestCase(TerraformBaseActionTestCase):
 
         mock_init.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -40,7 +38,6 @@ class InitTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_init.assert_called_with(
             backend_config=test_backend,
             capture_output=False,
@@ -50,7 +47,7 @@ class InitTestCase(TerraformBaseActionTestCase):
 
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
-    def test_run_upgrade_true(self, mock_init, mock_check_result, mock_chdir):
+    def test_run_upgrade_true(self, mock_init, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -65,8 +62,6 @@ class InitTestCase(TerraformBaseActionTestCase):
 
         mock_init.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -76,7 +71,6 @@ class InitTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_init.assert_called_with(
             backend_config=test_backend,
             capture_output=False,
@@ -86,7 +80,7 @@ class InitTestCase(TerraformBaseActionTestCase):
 
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.init")
-    def test_run_upgrade_none(self, mock_init, mock_check_result, mock_chdir):
+    def test_run_upgrade_none(self, mock_init, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -101,8 +95,6 @@ class InitTestCase(TerraformBaseActionTestCase):
 
         mock_init.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -112,7 +104,6 @@ class InitTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_init.assert_called_with(
             backend_config=test_backend,
             capture_output=False,

--- a/tests/test_action_list_workspaces.py
+++ b/tests/test_action_list_workspaces.py
@@ -11,10 +11,9 @@ class ListWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, ListWorkspaces)
 
-    @mock.patch("list_workspaces.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result, mock_chdir):
+    def test_run(self, mock_workspace, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -27,8 +26,6 @@ class ListWorkspaceTestCase(TerraformBaseActionTestCase):
 
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -38,7 +35,6 @@ class ListWorkspaceTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_workspace.assert_called_with("workspace")
         action.terraform.workspace.assert_called_with("list")
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_list_workspaces.py
+++ b/tests/test_action_list_workspaces.py
@@ -38,5 +38,5 @@ class ListWorkspaceTestCase(TerraformBaseActionTestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         mock_workspace.assert_called_with("workspace")
-        action.terraform.workspace.assert_called_with("list")
+        action.terraform.workspace.assert_called_with("list", raise_on_error=False)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_list_workspaces.py
+++ b/tests/test_action_list_workspaces.py
@@ -11,9 +11,10 @@ class ListWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, ListWorkspaces)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result):
+    def test_run(self, mock_workspace, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -24,6 +25,7 @@ class ListWorkspaceTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"

--- a/tests/test_action_output.py
+++ b/tests/test_action_output.py
@@ -11,8 +11,9 @@ class OutputTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Output)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.Terraform.output")
-    def test_run_state_file(self, mock_output):
+    def test_run_state_file(self, mock_output, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -23,6 +24,8 @@ class OutputTestCase(TerraformBaseActionTestCase):
         expected_result = "result"
         mock_output.return_value = expected_result
 
+        mock_version.return_value = '1.1.1'
+
         # Execute the run function
         result = action.run(test_plan_path, test_state_file_path, test_terraform_exec)
 
@@ -32,8 +35,9 @@ class OutputTestCase(TerraformBaseActionTestCase):
         self.assertTrue(mock_output.called)
         mock_output.assert_called_with(state=test_state_file_path)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.Terraform.output")
-    def test_run_no_state_file(self, mock_output):
+    def test_run_no_state_file(self, mock_output, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -42,6 +46,8 @@ class OutputTestCase(TerraformBaseActionTestCase):
         # Declare test Terraform.output return values
         expected_result = "result"
         mock_output.return_value = expected_result
+
+        mock_version.return_value = '1.1.1'
 
         # Execute the run function
         result = action.run(test_plan_path, None, test_terraform_exec)

--- a/tests/test_action_output.py
+++ b/tests/test_action_output.py
@@ -11,9 +11,8 @@ class OutputTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Output)
 
-    @mock.patch("output.os.chdir")
     @mock.patch("lib.action.Terraform.output")
-    def test_run_state_file(self, mock_output, mock_chdir):
+    def test_run_state_file(self, mock_output):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -24,8 +23,6 @@ class OutputTestCase(TerraformBaseActionTestCase):
         expected_result = "result"
         mock_output.return_value = expected_result
 
-        mock_chdir.return_value = "success"
-
         # Execute the run function
         result = action.run(test_plan_path, test_state_file_path, test_terraform_exec)
 
@@ -33,12 +30,10 @@ class OutputTestCase(TerraformBaseActionTestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertTrue(mock_output.called)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_output.assert_called_with(state=test_state_file_path)
 
-    @mock.patch("output.os.chdir")
     @mock.patch("lib.action.Terraform.output")
-    def test_run_no_state_file(self, mock_output, mock_chdir):
+    def test_run_no_state_file(self, mock_output):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -48,8 +43,6 @@ class OutputTestCase(TerraformBaseActionTestCase):
         expected_result = "result"
         mock_output.return_value = expected_result
 
-        mock_chdir.return_value = "success"
-
         # Execute the run function
         result = action.run(test_plan_path, None, test_terraform_exec)
 
@@ -57,5 +50,4 @@ class OutputTestCase(TerraformBaseActionTestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertTrue(mock_output.called)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_output.assert_called_with(state=None)

--- a/tests/test_action_plan.py
+++ b/tests/test_action_plan.py
@@ -13,7 +13,7 @@ class PlanTestCase(TerraformBaseActionTestCase):
 
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.plan")
-    def test_run(self, mock_plan, mock_check_result, mock_chdir):
+    def test_run(self, mock_plan, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -30,8 +30,6 @@ class PlanTestCase(TerraformBaseActionTestCase):
 
         mock_plan.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -46,7 +44,6 @@ class PlanTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertEqual(action.terraform.var_file, test_variable_files)
         self.assertEqual(action.terraform.variables, test_variable_dict)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_plan.assert_called_with(test_plan_path, capture_output=False)
         mock_check_result.assert_called_with(
             test_return_code,
@@ -58,7 +55,7 @@ class PlanTestCase(TerraformBaseActionTestCase):
 
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.plan")
-    def test_run_exit_code_2(self, mock_plan, mock_check_result, mock_chdir):
+    def test_run_exit_code_2(self, mock_plan, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -75,8 +72,6 @@ class PlanTestCase(TerraformBaseActionTestCase):
 
         mock_plan.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -91,7 +86,6 @@ class PlanTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertEqual(action.terraform.var_file, test_variable_files)
         self.assertEqual(action.terraform.variables, test_variable_dict)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_plan.assert_called_with(test_plan_path, capture_output=False)
         mock_check_result.assert_called_with(
             test_return_code,

--- a/tests/test_action_plan.py
+++ b/tests/test_action_plan.py
@@ -11,7 +11,6 @@ class PlanTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Plan)
 
-    @mock.patch("list_workspaces.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.plan")
     def test_run(self, mock_plan, mock_check_result, mock_chdir):
@@ -57,7 +56,6 @@ class PlanTestCase(TerraformBaseActionTestCase):
             valid_return_codes=[0, 2]
         )
 
-    @mock.patch("list_workspaces.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.plan")
     def test_run_exit_code_2(self, mock_plan, mock_check_result, mock_chdir):

--- a/tests/test_action_plan.py
+++ b/tests/test_action_plan.py
@@ -11,9 +11,10 @@ class PlanTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Plan)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.plan")
-    def test_run(self, mock_plan, mock_check_result):
+    def test_run(self, mock_plan, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -28,6 +29,7 @@ class PlanTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_plan.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"
@@ -53,9 +55,10 @@ class PlanTestCase(TerraformBaseActionTestCase):
             valid_return_codes=[0, 2]
         )
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.plan")
-    def test_run_exit_code_2(self, mock_plan, mock_check_result):
+    def test_run_exit_code_2(self, mock_plan, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -70,6 +73,7 @@ class PlanTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         mock_plan.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"

--- a/tests/test_action_plan.py
+++ b/tests/test_action_plan.py
@@ -46,7 +46,7 @@ class PlanTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertEqual(action.terraform.var_file, test_variable_files)
         self.assertEqual(action.terraform.variables, test_variable_dict)
-        mock_plan.assert_called_with(test_plan_path, capture_output=False)
+        mock_plan.assert_called_with(capture_output=False, raise_on_error=False)
         mock_check_result.assert_called_with(
             test_return_code,
             test_stdout,
@@ -90,7 +90,7 @@ class PlanTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         self.assertEqual(action.terraform.var_file, test_variable_files)
         self.assertEqual(action.terraform.variables, test_variable_dict)
-        mock_plan.assert_called_with(test_plan_path, capture_output=False)
+        mock_plan.assert_called_with(capture_output=False, raise_on_error=False)
         mock_check_result.assert_called_with(
             test_return_code,
             test_stdout,

--- a/tests/test_action_select_workspace.py
+++ b/tests/test_action_select_workspace.py
@@ -11,10 +11,9 @@ class SelectWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, SelectWorkspace)
 
-    @mock.patch("select_workspace.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result, mock_chdir):
+    def test_run(self, mock_workspace, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -28,8 +27,6 @@ class SelectWorkspaceTestCase(TerraformBaseActionTestCase):
 
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -39,7 +36,6 @@ class SelectWorkspaceTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_workspace.assert_called_with("workspace")
         action.terraform.workspace.assert_called_with("select", test_workspace, "-no-color")
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_select_workspace.py
+++ b/tests/test_action_select_workspace.py
@@ -11,9 +11,10 @@ class SelectWorkspaceTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, SelectWorkspace)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_workspace, mock_check_result):
+    def test_run(self, mock_workspace, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -25,6 +26,7 @@ class SelectWorkspaceTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         action.terraform.workspace.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"

--- a/tests/test_action_select_workspace.py
+++ b/tests/test_action_select_workspace.py
@@ -39,5 +39,8 @@ class SelectWorkspaceTestCase(TerraformBaseActionTestCase):
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         mock_workspace.assert_called_with("workspace")
-        action.terraform.workspace.assert_called_with("select", test_workspace, "-no-color")
+        action.terraform.workspace.assert_called_with("select",
+                                                      test_workspace,
+                                                      "-no-color",
+                                                      raise_on_error=False)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)

--- a/tests/test_action_show.py
+++ b/tests/test_action_show.py
@@ -11,9 +11,10 @@ class ShowTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Show)
 
+    @mock.patch("lib.action.TerraformBaseAction.set_semantic_version")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_show, mock_check_result):
+    def test_run(self, mock_show, mock_check_result, mock_version):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -24,6 +25,7 @@ class ShowTestCase(TerraformBaseActionTestCase):
         test_stdout = "Terraform has been successfully initialized!"
         test_stderr = ""
 
+        mock_version.return_value = '1.1.1'
         action.terraform.show.return_value = test_return_code, test_stdout, test_stderr
 
         expected_result = "result"

--- a/tests/test_action_show.py
+++ b/tests/test_action_show.py
@@ -39,4 +39,4 @@ class ShowTestCase(TerraformBaseActionTestCase):
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
         mock_show.assert_called_with("show")
-        action.terraform.show.assert_called_with("-no-color")
+        action.terraform.show.assert_called_with("-no-color", raise_on_error=False)

--- a/tests/test_action_show.py
+++ b/tests/test_action_show.py
@@ -11,10 +11,9 @@ class ShowTestCase(TerraformBaseActionTestCase):
         action = self.get_action_instance({})
         self.assertIsInstance(action, Show)
 
-    @mock.patch("show.os.chdir")
     @mock.patch("lib.action.TerraformBaseAction.check_result")
     @mock.patch("lib.action.Terraform.__getattr__")
-    def test_run(self, mock_show, mock_check_result, mock_chdir):
+    def test_run(self, mock_show, mock_check_result):
         action = self.get_action_instance({})
         # Declare test input values
         test_plan_path = "/terraform"
@@ -27,8 +26,6 @@ class ShowTestCase(TerraformBaseActionTestCase):
 
         action.terraform.show.return_value = test_return_code, test_stdout, test_stderr
 
-        mock_chdir.return_value = "success"
-
         expected_result = "result"
         mock_check_result.return_value = expected_result
 
@@ -38,7 +35,6 @@ class ShowTestCase(TerraformBaseActionTestCase):
         # Verify the results
         self.assertEqual(result, expected_result)
         self.assertEqual(action.terraform.terraform_bin_path, test_terraform_exec)
-        mock_chdir.assert_called_with(test_plan_path)
         mock_check_result.assert_called_with(test_return_code, test_stdout, test_stderr)
         mock_show.assert_called_with("show")
         action.terraform.show.assert_called_with("-no-color")


### PR DESCRIPTION
Removing calls to os.chdir and setting path to working_dir

( https://developer.hashicorp.com/terraform/language/v1.1.x/upgrade-guides/0-15#commands-accepting-a-configuration-directory-argument )

Fixes 'Too many command line arguments. Did you mean to use -chdir?' errors

Also fixes unit tests